### PR TITLE
CO-1121 Remove logs folder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 npm-debug.log
 node_modules
 build
+configs

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ npm-debug.log
 node_modules
 build
 configs
+logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ RUN cd /opt/oracle/instantclient_12_2 \
 RUN echo /opt/oracle/instantclient_12_2 > /etc/ld.so.conf.d/oracle-instantclient.conf \
  && ldconfig
 
+RUN gulp test && rm -rf logs
 USER nobody:nogroup
-CMD ["gulp", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,5 @@ RUN echo /opt/oracle/instantclient_12_2 > /etc/ld.so.conf.d/oracle-instantclient
 
 RUN gulp test && rm -rf logs
 USER nobody:nogroup
+
+ENTRYPOINT ["gulp", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN cd /opt/oracle/instantclient_12_2 \
 RUN echo /opt/oracle/instantclient_12_2 > /etc/ld.so.conf.d/oracle-instantclient.conf \
  && ldconfig
 
-RUN gulp test && rm -rf logs
+RUN gulp test
 USER nobody:nogroup
 
 ENTRYPOINT ["gulp", "run"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Report the people who used the staff fee privilege for each term.
 
     | Option | Description |
     | ------ | ----------- |
+    | **enable** | A boolean to enable logger. |
     | **size** | Maximum size of the file after which it will rotate. This can be a number of bytes, or units of kb, mb, and gb. If using the units, add 'k', 'm', or 'g' as the suffix. The units need to directly follow the number. |
     | **path** | The directory name to save log files to. |
     | **pattern** | A string representing the [moment.js date format](https://momentjs.com/docs/#/displaying/format/) to be used for rotating. The meta characters used in this string will dictate the frequency of the file rotation. For example, if your datePattern is simply 'HH' you will end up with 24 log files that are picked up and appended to every day. |

--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ const adminApp = express();
 const adminAppRouter = express.Router();
 
 // Middlewares
-app.use(logger);
+if (logger) app.use(logger);
 app.use(serverConfig.basePath, appRouter);
 appRouter.use(authentication);
 

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -10,3 +10,5 @@ database:
   connectString: 'DBURL'
   user: 'DBUSER'
   password: 'DBPASSWD'
+logger:
+  enable: 'ENABLE_LOGGER'

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -22,6 +22,7 @@ database:
   poolMax: 30
 
 logger:
+  enable: false
   size: 10m
   path: logs
   pattern: YYYY-MM-DD

--- a/middlewares/logger.js
+++ b/middlewares/logger.js
@@ -6,25 +6,28 @@ require('winston-daily-rotate-file');
 const loggerConfig = config.get('logger');
 const apiName = config.get('api').name;
 
-// Transport for daily rotate file
-const dailyRotateFileTransport = new (winston.transports.DailyRotateFile)({
-  filename: `${apiName}-%DATE%.log`,
-  datePattern: loggerConfig.pattern,
-  maxSize: loggerConfig.size,
-  zippedArchive: loggerConfig.archive,
-  dirname: loggerConfig.path,
-});
+let logger;
+if (loggerConfig.enable) {
+  // Transport for daily rotate file
+  const dailyRotateFileTransport = new (winston.transports.DailyRotateFile)({
+    filename: `${apiName}-%DATE%.log`,
+    datePattern: loggerConfig.pattern,
+    maxSize: loggerConfig.size,
+    zippedArchive: loggerConfig.archive,
+    dirname: loggerConfig.path,
+  });
 
-// Transport for console output
-const consoleTransport = new winston.transports.Console({
-  json: loggerConfig.jsonConsole,
-  colorize: loggerConfig.colorize,
-});
+  // Transport for console output
+  const consoleTransport = new winston.transports.Console({
+    json: loggerConfig.jsonConsole,
+    colorize: loggerConfig.colorize,
+  });
 
-const logger = expressWinston.logger({
-  transports: [dailyRotateFileTransport, consoleTransport],
-  expressFormat: true,
-  colorize: loggerConfig.colorize,
-});
+  logger = expressWinston.logger({
+    transports: [dailyRotateFileTransport, consoleTransport],
+    expressFormat: true,
+    colorize: loggerConfig.colorize,
+  });
+}
 
 module.exports = { logger };


### PR DESCRIPTION
Since we were using `CMD` to run `gulp test`, it will only run the command when the container is started. This means that an empty logs folder will be created when Jenkins starts the container, then bakes the logs folder into the artifacts. When the artifact is copied to the api vm and be imported, all of the files from the original container are owned by root (but executable) by default. However, since we are running the container as osu_apis, so we won't have the correct permission to write log into logs folder. Therefore, this PR is to run `gulp test` while building the images and delete the logs folder once it's ready to be exported.