### PR TITLE
Fix ORA-02396 error

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -18,8 +18,9 @@ database:
   connectString: ${DBURL}
   user: ${DBUSER}
   password: ${DBPASSWD}
-  poolMin: 3
-  poolMax: 30
+  poolMin: 5
+  poolMax: 5
+  poolIncrement: 0
 
 logger:
   size: 10m


### PR DESCRIPTION
* Staff-fee-privilege API ran into the following issue:

    ```
    Error: ORA-02396: exceeded maximum idle time, please connect again
    ```

This PR is to fix this issue by following this comment: https://github.com/oracle/node-oracledb/issues/928#issuecomment-398238519

* The default value of poolIncrement is 1. It will cause the issue Error: ORA-24413: Invalid number of sessions specified if poolMin and poolMax are the same.