### PR TITLE
Follow jsonapi specification

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,11 +31,13 @@ adminAppRouter.get('/', async (req, res) => {
     const commit = await git().revparse(['--short', 'HEAD']);
     const now = moment();
     const info = {
-      name: `${config.get('api').name}-api`,
-      time: now.format('YYYY-MM-DD HH:mm:ssZZ'),
-      unixTime: now.unix(),
-      commit: commit.trim(),
-      documentation: 'swagger.yaml',
+      meta: {
+        name: `${config.get('api').name}-api`,
+        time: now.format('YYYY-MM-DD HH:mm:ssZZ'),
+        unixTime: now.unix(),
+        commit: commit.trim(),
+        documentation: 'swagger.yaml',
+      },
     };
     res.send(info);
   } catch (err) {


### PR DESCRIPTION
When reviewing [CO-1136](https://github.com/osu-mist/web-api-skeleton/pull/70/files#r211041097) by @wilsonia , I realized that the top-level endpoint of this API didn't follow [JSON API specification](http://jsonapi.org/format/#document-top-level) as well :( This ticket is to fix it.